### PR TITLE
feat: add client-side validation to NewBookPage (required fields, inl…

### DIFF
--- a/digital-library-client/src/pages/NewBookPage.jsx
+++ b/digital-library-client/src/pages/NewBookPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 
 /*
@@ -8,15 +8,46 @@ import { Link } from 'react-router-dom'
  */
 export default function NewBookPage() {
   const [form, setForm] = useState({ title: '', author: '', category: '' })
+  const [touched, setTouched] = useState({})
+  const [submitted, setSubmitted] = useState(false)
+  const refs = {
+    title: useRef(null),
+    author: useRef(null),
+    category: useRef(null)
+  }
+
+  function validate(values = form) {
+    const errors = {}
+    if (!values.title.trim()) errors.title = 'Title is required'
+    if (!values.author.trim()) errors.author = 'Author is required'
+    if (!values.category.trim()) errors.category = 'Category is required'
+    return errors
+  }
+
+  const errors = validate()
+  const isValid = Object.keys(errors).length === 0
 
   function handleChange(e) {
     const { name, value } = e.target
     setForm(prev => ({ ...prev, [name]: value }))
   }
 
+  function handleBlur(e) {
+    const { name } = e.target
+    setTouched(prev => ({ ...prev, [name]: true }))
+  }
+
   function handleSubmit(e) {
     e.preventDefault()
-    // Placeholder submit (will integrate with backend later)
+    setSubmitted(true)
+    if (!isValid) {
+      // focus first error field
+      const firstErrorField = ['title','author','category'].find(f => errors[f])
+      if (firstErrorField && refs[firstErrorField].current) {
+        refs[firstErrorField].current.focus()
+      }
+      return
+    }
     console.log('Submitting new book', form)
     alert('Book submitted (demo).')
   }
@@ -24,26 +55,29 @@ export default function NewBookPage() {
   return (
     <div className="card" style={{ maxWidth: 480 }}>
       <h2>Register a Book</h2>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      <form onSubmit={handleSubmit} noValidate style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
         <div>
           <label htmlFor="title">Title</label><br />
-          <input id="title" name="title" value={form.title} onChange={handleChange} placeholder="e.g. The Pragmatic Programmer" />
+          <input ref={refs.title} id="title" name="title" value={form.title} onChange={handleChange} onBlur={handleBlur} aria-invalid={!!errors.title} aria-describedby={errors.title ? 'title-error' : undefined} placeholder="e.g. The Pragmatic Programmer" />
+          {(touched.title || submitted) && errors.title && <div id="title-error" style={{ color: 'crimson', fontSize: '0.8rem' }}>{errors.title}</div>}
         </div>
         <div>
           <label htmlFor="author">Author</label><br />
-            <input id="author" name="author" value={form.author} onChange={handleChange} placeholder="e.g. Andrew Hunt" />
+          <input ref={refs.author} id="author" name="author" value={form.author} onChange={handleChange} onBlur={handleBlur} aria-invalid={!!errors.author} aria-describedby={errors.author ? 'author-error' : undefined} placeholder="e.g. Andrew Hunt" />
+          {(touched.author || submitted) && errors.author && <div id="author-error" style={{ color: 'crimson', fontSize: '0.8rem' }}>{errors.author}</div>}
         </div>
         <div>
           <label htmlFor="category">Category</label><br />
-          <select id="category" name="category" value={form.category} onChange={handleChange}>
+          <select ref={refs.category} id="category" name="category" value={form.category} onChange={handleChange} onBlur={handleBlur} aria-invalid={!!errors.category} aria-describedby={errors.category ? 'category-error' : undefined}>
             <option value="">-- Select Category --</option>
             <option value="Fiction">Fiction</option>
             <option value="Science">Science</option>
             <option value="History">History</option>
             <option value="Technology">Technology</option>
           </select>
+          {(touched.category || submitted) && errors.category && <div id="category-error" style={{ color: 'crimson', fontSize: '0.8rem' }}>{errors.category}</div>}
         </div>
-        <button type="submit">Save Book</button>
+        <button type="submit" disabled={!isValid}>Save Book</button>
       </form>
       <p style={{ marginTop: '1rem' }}><Link to="/">Back to Home</Link></p>
     </div>


### PR DESCRIPTION
…ine errors, disabled submit)
This pull request adds client-side form validation and accessibility improvements to the `NewBookPage` component. The form now provides real-time validation feedback, disables the submit button until the form is valid, and improves accessibility for users with assistive technologies.

**Form validation and UX improvements:**

* Added `validate` function to check for required fields (`title`, `author`, `category`) and display error messages when fields are empty.
* Introduced `touched` and `submitted` state to control when validation errors are shown, providing immediate feedback after a field is interacted with or after form submission.
* Disabled the "Save Book" button until the form is valid, preventing accidental submissions with missing data.
* On submit, if there are validation errors, the first invalid field is automatically focused for better user experience.

**Accessibility enhancements:**

* Added `aria-invalid` and `aria-describedby` attributes to form fields to improve screen reader support for error messages.
* Used refs to manage focus on validation errors, enhancing keyboard navigation and accessibility.

<img width="343" height="539" alt="image" src="https://github.com/user-attachments/assets/8b64dc9b-1d6b-4ad2-9837-c32538e150a2" />
